### PR TITLE
Prevent bypassing ThreadHideFromDebugger/NtSetInformationThread hook to real syscall

### DIFF
--- a/HookLibrary/HookedFunctions.cpp
+++ b/HookLibrary/HookedFunctions.cpp
@@ -30,7 +30,7 @@ extern WCHAR ExplorerProcessName[13];
 
 NTSTATUS NTAPI HookedNtSetInformationThread(HANDLE ThreadHandle, THREADINFOCLASS ThreadInformationClass, PVOID ThreadInformation, ULONG ThreadInformationLength)
 {
-    if (ThreadInformationClass == ThreadHideFromDebugger && ThreadInformation == 0 && ThreadInformationLength == 0)
+    if (ThreadInformationClass == ThreadHideFromDebugger && ThreadInformationLength == 0) // NB: ThreadInformation is not checked, this is deliberate
     {
         if (ThreadHandle == NtCurrentThread || GetCurrentProcessId() == GetProcessIdByThreadHandle(ThreadHandle)) //thread inside this process?
         {


### PR DESCRIPTION
HookedNtSetInformationThread is a bit overzealous in its parameter validation, and requires ThreadInformation to be NULL before the call is considered for hooking. (I'm guessing that this is based on the assumption that since ThreadInformationLength must be 0, ThreadInformation must also be NULL since the Nt/Zw calls normally follow the convention that XxxLength == sizeof(XxxInformation)). However, ThreadInformation is in no way checked or referenced whatsoever by NtSetInformationThread in the case that ThreadInformationClass == ThreadHideFromDebugger. Thus the following call will succeed with STATUS_SUCCESS:
```C++
NtSetInformationThread(GetCurrentThread(), ThreadHideFromDebugger, (PVOID)0x1234, 0);
```
I tested this on Windows XP, 7 and 10, and lost control of the debugged process every time, so this really works. You can easily see from the function that calling NtSetInformationThread in this way will bypass the hook completely.

The solution is to simply delete the extra check and ignore the parameter the same way NtSetInformationThread does.

By the way, the same bug is present in TitanHide, but if I'm not mistaken making a report there would just mean spamming the same mailbox twice ;)