### PR TITLE
Don't call DllMain on each DLL (un)load

### DIFF
--- a/HookLibrary/DllMain.cpp
+++ b/HookLibrary/DllMain.cpp
@@ -1,4 +1,4 @@
-#include <windows.h>
+#include <ntdll/ntdll.h>
 
 #ifdef NDEBUG
 #pragma comment(linker, "/ENTRY:DllMain")
@@ -6,5 +6,6 @@
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
+    LdrDisableThreadCalloutsForDll(hinstDLL);
     return TRUE;
 }


### PR DESCRIPTION
This prevents ntdll from calling the DllMain of HookLibrary.dll (which shouldn't be visible to the process) for every DLL load/unload event.