### PR TITLE
Fixed ERROR_ACCESS_VIOLATION for SystemHandleInformation in HookedNtQuerySystemInformation

### DIFF
--- a/HookLibrary/HookedFunctions.cpp
+++ b/HookLibrary/HookedFunctions.cpp
@@ -75,7 +75,7 @@ NTSTATUS NTAPI HookedNtQuerySystemInformation(SYSTEM_INFORMATION_CLASS SystemInf
                 FilterHandleInfo((PSYSTEM_HANDLE_INFORMATION)SystemInformation, &ReturnLengthAdjust);
 
                 if (ReturnLengthAdjust <= TempReturnLength)
-				    ReturnLength -= ReturnLengthAdjust;
+				    TempReturnLength -= ReturnLengthAdjust;
                 RESTORE_RETURNLENGTH();
             }
             else if (SystemInformationClass == SystemExtendedHandleInformation)
@@ -86,7 +86,7 @@ NTSTATUS NTAPI HookedNtQuerySystemInformation(SYSTEM_INFORMATION_CLASS SystemInf
                 FilterHandleInfoEx((PSYSTEM_HANDLE_INFORMATION_EX)SystemInformation, &ReturnLengthAdjust);
 
                 if (ReturnLengthAdjust <= TempReturnLength)
-                    ReturnLength -= ReturnLengthAdjust;
+                    TempReturnLength -= ReturnLengthAdjust;
                 RESTORE_RETURNLENGTH();
             }
             else if (SystemInformationClass == SystemProcessInformation ||


### PR DESCRIPTION
I just checked `HookedNtQuerySystemInformation` and I noticed something odd. After reading issue #47 and testing the pointer arithmetic I am sure that it is a bug.

Starting on lines 72 and 83 of `HookedFunctions.cpp` we have the [following code](https://github.com/x64dbg/ScyllaHide/blob/vs13/HookLibrary/HookedFunctions.cpp#L72
):
```
BACKUP_RETURNLENGTH();
ULONG ReturnLengthAdjust = 0;

FilterHandleInfo((PSYSTEM_HANDLE_INFORMATION)SystemInformation, &ReturnLengthAdjust);

if (ReturnLengthAdjust <= TempReturnLength)
    ReturnLength -= ReturnLengthAdjust; // L.78
RESTORE_RETURNLENGTH();
```
The `BACKUP_RETURNLENGTH/RESTORE_RETURNLENGTH` macros resolve to:

```
#define BACKUP_RETURNLENGTH() \
    ULONG TempReturnLength = 0; \
    if(ReturnLength != nullptr) \
        TempReturnLength = *ReturnLength

#define RESTORE_RETURNLENGTH() \
    if(ReturnLength != nullptr) \
        (*ReturnLength) = TempReturnLength
```

I think `ReturnLength` on lines 78 und 89 should instead be `TempReturnLength` since it should adjust the value that gets restored via `RESTORE_RETURNLENGTH` and not subtract from the `ReturnLength` pointer.

So currently in those two cases the size adjust does not take place, instead the `ReturnLength` pointer is decremented by `ReturnLengthAdjust` and then the `RESTORE_RETURNLENGTH` macro writes back the previously saved value to the arbirtray memory location `ReturnLength` now points to. This will result in `ERROR_ACCESS_VIOLATION` most of the time but at least it leads to undefined behaviour.

I tested it and the fix is really simple so I am directly including a PR. Greetings and have a nice day.
