### PR TITLE
Only apply PEB changes once

### DIFF
--- a/HookLibrary/HookMain.h
+++ b/HookLibrary/HookMain.h
@@ -155,6 +155,7 @@ typedef struct _HOOK_DLL_DATA {
     BOOLEAN isNtdllHooked;
     BOOLEAN isKernel32Hooked;
     BOOLEAN isUserDllHooked;
+    BOOLEAN isPebHooked;
 
 #ifndef _WIN64
     HOOK_NATIVE_CALL32 HookNative[MAX_NATIVE_HOOKS];


### PR DESCRIPTION
The OsBuildNumber patch increments the build number in the PEB by 1, and this gets called multiple times, meaning a debuggee could detect us by watching for changes in the build number.

This change adds a boolean to HOOK_DLL_DATA and makes sure we only apply the PEB patches once.

It might be nice in future to use the HOOK_DLL_DATA struct to save and restore the PEB values if someone was interested in a truly reversable hook/unhook setup, future work.