### PR TITLE
Fix according to newest x64dbg changes

### DIFF
--- a/ScyllaHideX64DBGPlugin/ScyllaHideX64DBGPlugin.cpp
+++ b/ScyllaHideX64DBGPlugin/ScyllaHideX64DBGPlugin.cpp
@@ -190,14 +190,6 @@ static void cbDebugloop(CBTYPE cbType, void* callbackInfo)
         {
         case STATUS_BREAKPOINT:
         {
-            /*if (!bHooked)
-            {
-                ReadNtApiInformation(&g_hdd);
-
-                bHooked = true;
-                startInjection(ProcessId, &g_hdd, g_scyllaHideDllPath.c_str(), true);
-            }*/
-
             break;
         }
 

--- a/ScyllaHideX64DBGPlugin/ScyllaHideX64DBGPlugin.cpp
+++ b/ScyllaHideX64DBGPlugin/ScyllaHideX64DBGPlugin.cpp
@@ -164,6 +164,14 @@ static void cbDebugloop(CBTYPE cbType, void* callbackInfo)
                     MessageBoxW(hwndDlg, L"Anti-Anti-Attach failed", L"Error", MB_ICONERROR);
                 }
             }
+            //In newest x64dbg version the auto break on attach was removed so ScyllaHide would never inject.
+            if (!bHooked)
+            {
+                ReadNtApiInformation(&g_hdd);
+
+                bHooked = true;
+                startInjection(ProcessId, &g_hdd, g_scyllaHideDllPath.c_str(), true);
+            }
         }
 
         break;
@@ -182,13 +190,13 @@ static void cbDebugloop(CBTYPE cbType, void* callbackInfo)
         {
         case STATUS_BREAKPOINT:
         {
-            if (!bHooked)
+            /*if (!bHooked)
             {
                 ReadNtApiInformation(&g_hdd);
 
                 bHooked = true;
                 startInjection(ProcessId, &g_hdd, g_scyllaHideDllPath.c_str(), true);
-            }
+            }*/
 
             break;
         }


### PR DESCRIPTION
In newest x64dbg version the auto break on attach was removed so ScyllaHide would never inject unless you manually break and It's already too late