### PR TITLE
Add compatibility for VMProtect 3.6+

### DIFF
--- a/3rdparty/ntdll/ntdll.h
+++ b/3rdparty/ntdll/ntdll.h
@@ -4536,6 +4536,47 @@ NTSTATUS
 	PSIZE_T NumberOfBytesWritten
 	);
 
+typedef
+NTSTATUS
+(NTAPI
+*t_NtOpenFile)(
+    _Out_ PHANDLE FileHandle,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ POBJECT_ATTRIBUTES ObjectAttributes,
+    _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+    _In_ ULONG ShareAccess,
+    _In_ ULONG OpenOptions
+    );
+
+typedef
+NTSTATUS
+(NTAPI
+*t_NtCreateSection)(
+    _Out_ PHANDLE SectionHandle,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_opt_ POBJECT_ATTRIBUTES ObjectAttributes,
+    _In_opt_ PLARGE_INTEGER MaximumSize,
+    _In_ ULONG SectionPageProtection,
+    _In_ ULONG AllocationAttributes,
+    _In_opt_ HANDLE FileHandle
+    );
+
+typedef
+NTSTATUS
+(NTAPI
+*t_NtMapViewOfSection)(
+    _In_ HANDLE SectionHandle,
+    _In_ HANDLE ProcessHandle,
+    _Inout_ _At_(*BaseAddress, _Readable_bytes_(*ViewSize) _Writable_bytes_(*ViewSize) _Post_readable_byte_size_(*ViewSize)) PVOID* BaseAddress,
+    _In_ ULONG_PTR ZeroBits,
+    _In_ SIZE_T CommitSize,
+    _Inout_opt_ PLARGE_INTEGER SectionOffset,
+    _Inout_ PSIZE_T ViewSize,
+    _In_ SECTION_INHERIT InheritDisposition,
+    _In_ ULONG AllocationType,
+    _In_ ULONG Win32Protect
+    );
+
 // win32k system calls
 // BlockInput
 typedef

--- a/HookLibrary/Export.def
+++ b/HookLibrary/Export.def
@@ -31,3 +31,6 @@ HookedNtUserQueryWindow
 HookedNtYieldExecution
 HookedOutputDebugStringA
 HookedNtResumeThread
+HookedNtOpenFile
+HookedNtCreateSection
+HookedNtMapViewOfSection

--- a/HookLibrary/HookLibrary.vcxproj
+++ b/HookLibrary/HookLibrary.vcxproj
@@ -167,6 +167,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\Scylla\VersionPatch.cpp" />
     <ClCompile Include="HookedFunctions.cpp" />
     <ClCompile Include="HookHelper.cpp" />
     <ClCompile Include="DllMain.cpp" />
@@ -175,6 +176,7 @@
     <None Include="Export.def" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\Scylla\VersionPatch.h" />
     <ClInclude Include="HookedFunctions.h" />
     <ClInclude Include="HookHelper.h" />
     <ClInclude Include="HookMain.h" />

--- a/HookLibrary/HookLibrary.vcxproj.filters
+++ b/HookLibrary/HookLibrary.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClCompile Include="DllMain.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\Scylla\VersionPatch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Export.def">
@@ -41,6 +44,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Tls.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Scylla\VersionPatch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/HookLibrary/HookMain.h
+++ b/HookLibrary/HookMain.h
@@ -116,6 +116,13 @@ typedef struct _HOOK_DLL_DATA {
     t_NtCreateThread dNtCreateThread;
     DWORD NtCreateThreadBackupSize;
 
+    t_NtOpenFile dNtOpenFile;
+    DWORD NtOpenFileBackupSize;
+    t_NtCreateSection dNtCreateSection;
+    DWORD NtCreateSectionBackupSize;
+    t_NtMapViewOfSection dNtMapViewOfSection;
+    DWORD NtMapViewOfSectionBackupSize;
+
 	/////////////////////////////////////////////////////////
 	t_GetTickCount dGetTickCount;
 	DWORD GetTickCountBackupSize;

--- a/HookLibrary/HookedFunctions.h
+++ b/HookLibrary/HookedFunctions.h
@@ -68,3 +68,7 @@ VOID NTAPI HookedKiUserExceptionDispatcher();//(PEXCEPTION_RECORD pExcptRec, PCO
 HWND NTAPI HookedNtUserFindWindowEx(HWND hWndParent, HWND hWndChildAfter, PUNICODE_STRING lpszClass, PUNICODE_STRING lpszWindow, DWORD dwType);
 
 NTSTATUS NTAPI HookedNtResumeThread(HANDLE ThreadHandle, PULONG PreviousSuspendCount);
+
+NTSTATUS NTAPI HookedNtOpenFile(PHANDLE FileHandle, ACCESS_MASK DesiredAccess, POBJECT_ATTRIBUTES ObjectAttributes, PIO_STATUS_BLOCK IoStatusBlock, ULONG ShareAccess, ULONG OpenOptions);
+NTSTATUS NTAPI HookedNtCreateSection(PHANDLE SectionHandle, ACCESS_MASK DesiredAccess, POBJECT_ATTRIBUTES ObjectAttributes, PLARGE_INTEGER MaximumSize, ULONG SectionPageProtection, ULONG AllocationAttributes, HANDLE FileHandle);
+NTSTATUS NTAPI HookedNtMapViewOfSection(HANDLE SectionHandle, HANDLE ProcessHandle, PVOID* BaseAddress, ULONG_PTR ZeroBits, SIZE_T CommitSize, PLARGE_INTEGER SectionOffset, PSIZE_T ViewSize, SECTION_INHERIT InheritDisposition, ULONG AllocationType, ULONG Win32Protect);

--- a/InjectorCLI/InjectorCLI.vcxproj
+++ b/InjectorCLI/InjectorCLI.vcxproj
@@ -140,12 +140,14 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\PluginGeneric\Injector.cpp" />
+    <ClCompile Include="..\Scylla\VersionPatch.cpp" />
     <ClCompile Include="ApplyHooking.cpp" />
     <ClCompile Include="DynamicMapping.cpp" />
     <ClCompile Include="CliMain.cpp" />
     <ClCompile Include="RemoteHook.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\Scylla\VersionPatch.h" />
     <ClInclude Include="ApplyHooking.h" />
     <ClInclude Include="DynamicMapping.h" />
     <ClInclude Include="RemoteHook.h" />

--- a/InjectorCLI/InjectorCLI.vcxproj.filters
+++ b/InjectorCLI/InjectorCLI.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="..\PluginGeneric\Injector.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\Scylla\VersionPatch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DynamicMapping.h">
@@ -42,6 +45,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="resource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Scylla\VersionPatch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/PluginGeneric/OptionsDialog.cpp
+++ b/PluginGeneric/OptionsDialog.cpp
@@ -270,7 +270,7 @@ HWND CreateTooltips(HWND hDlg)
             IDC_PEB,
             L"The most important anti-anti-debug option.\r\n"
             L"Almost every protector checks for PEB values.\r\n"
-            L"There are three important options and one minor option."
+            L"There are three important options and some minor options."
         },
         {
             IDC_PEBBEINGDEBUGGED,
@@ -280,7 +280,10 @@ HWND CreateTooltips(HWND hDlg)
         { IDC_PEBHEAPFLAGS, L"Very important option, a lot of protectors check for this value." },
         { IDC_PEBNTGLOBALFLAG, L"Very important option. E.g. Themida checks for heap artifacts and heap flags." },
         { IDC_PEBSTARTUPINFO, L"This is not really important, only a few protectors check for this. Maybe Enigma checks it." },
-        { IDC_PEBOSBUILDNUMBER, L"VMProtect checks this on newer versions of Windows 10 (2019 onwards)." },
+        { IDC_PEBOSBUILDNUMBER, L"VMProtect checks this for determining syscall numbers for direct syscalls.\r\n"
+                                L"On Windows 10, you also need to put an access HWBP on KUSER_SHARED_DATA+0x260\r\n"
+                                L"and patch the build number manually.\r\n"
+                                L"NOTE: This won't have the desired effect for WOW64 processes!"},
         {
             IDC_NTSETINFORMATIONTHREAD,
             L"The THREADINFOCLASS value ThreadHideFromDebugger is a well-known\r\n"

--- a/Scylla/VersionPatch.cpp
+++ b/Scylla/VersionPatch.cpp
@@ -1,0 +1,124 @@
+#include "VersionPatch.h"
+
+#define STR(x) #x
+#define VERSTR(x) STR(x)
+#define FAKE_VERSION_WCHAR L"" VERSTR(FAKE_VERSION)
+
+bool NtVirtualProtect(HANDLE hProcess, PVOID Address, SIZE_T Size, ULONG NewProtect, PULONG OldProtect)
+{
+    PVOID BaseAddress = Address;
+    SIZE_T RegionSize = Size;
+    return NT_SUCCESS(NtProtectVirtualMemory(hProcess, &BaseAddress, &RegionSize, NewProtect, OldProtect));
+}
+
+void PatchFixedFileInfoVersion(HANDLE hProcess, PVOID Address, ULONG Size)
+{
+    BOOL found = FALSE;
+    PUCHAR P;
+    for (P = (PUCHAR)Address; P < (PUCHAR)Address + Size; ++P)
+    {
+        if (*(PDWORD)P == 0xFEEF04BD) // VS_FIXEDFILEINFO signature
+        {
+            found = TRUE;
+            break;
+        }
+    }
+    if (!found)
+    {
+        DbgPrint("Failed to find fixed version info signature in ntdll.dll VS_VERSION_INFO");
+        return;
+    }
+
+    P += 14; // Skip to FileVersion build number
+    ULONG OldProtect;
+    if (NtVirtualProtect(hProcess, P, 10, PAGE_READWRITE, &OldProtect))
+    {
+        WORD Version = FAKE_VERSION;
+        NtWriteVirtualMemory(hProcess, P, &Version, 2, nullptr); // FileVersion
+        NtWriteVirtualMemory(hProcess, P + 8, &Version, 2, nullptr); // ProductVersion
+        NtVirtualProtect(hProcess, P, 10, OldProtect, &OldProtect);
+    }
+    else
+    {
+        DbgPrint("VirtualProtectEx failed on ntdll");
+    }
+}
+
+void PatchVersionString(HANDLE hProcess, PVOID Address, ULONG Size, const WCHAR* Property)
+{
+    // VS_VERSIONINFO is a mess to navigate because it is a nested struct of variable size with (grand)children all of variable sizes
+    // See: https://docs.microsoft.com/en-gb/windows/win32/menurc/vs-versioninfo
+    // Instead of finding VS_VERSIONINFO -> StringFileInfo[] -> StringTable[] -> String (-> WCHAR[]) properly, just do it the memcmp way
+    size_t propertyLen = (wcslen(Property) + 1) * 2;
+    PUCHAR P = (PUCHAR)Address;
+    BOOL found = FALSE;
+    for (; P < (PUCHAR)Address + Size - propertyLen; ++P)
+    {
+        if (memcmp(P, Property, propertyLen) == 0)
+        {
+            found = TRUE;
+            break;
+        }
+    }
+    if (!found)
+    {
+        DbgPrint("Failed to find %ws in ntdll.dll VS_VERSION_INFO", Property);
+        return;
+    }
+
+    // Skip to the version number and discard extra nulls
+    P += propertyLen;
+    while (*(PWCHAR)P == L'\0')
+    {
+        P += sizeof(WCHAR);
+    }
+
+    // P now points at e.g. 6.1.xxxx.yyyy or 10.0.xxxxx.yyyy. Skip the major and minor version numbers to get to the build number xxxx
+    const ULONG Skip = NtCurrentPeb()->OSMajorVersion >= 10 ? 5 * sizeof(WCHAR) : 4 * sizeof(WCHAR);
+    P += Skip;
+
+    // Write a new bogus build number
+    WCHAR NewBuildNumber[] = FAKE_VERSION_WCHAR;
+    ULONG OldProtect;
+    if (NtVirtualProtect(hProcess, P, sizeof(NewBuildNumber) - sizeof(WCHAR), PAGE_READWRITE, &OldProtect))
+    {
+        SIZE_T NumWritten;
+        NtWriteVirtualMemory(hProcess, P, NewBuildNumber, sizeof(NewBuildNumber) - sizeof(WCHAR), &NumWritten);
+        NtVirtualProtect(hProcess, P, sizeof(NewBuildNumber) - sizeof(WCHAR), OldProtect, &OldProtect);
+    }
+}
+
+void ApplyNtdllVersionPatch(HANDLE hProcess, PVOID Ntdll)
+{
+    // Get the resource data entry for VS_VERSION_INFO
+    LDR_RESOURCE_INFO ResourceIdPath;
+    ResourceIdPath.Type = (ULONG_PTR)RT_VERSION;
+    ResourceIdPath.Name = VS_VERSION_INFO;
+    ResourceIdPath.Language = MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL);
+    PIMAGE_RESOURCE_DATA_ENTRY ResourceDataEntry = nullptr;
+    NTSTATUS Status = LdrFindResource_U(Ntdll, &ResourceIdPath, 3, &ResourceDataEntry);
+    if (!NT_SUCCESS(Status))
+    {
+        DbgPrint("Failed to find VS_VERSION_INFO resource in ntdll.dll: %08X", Status);
+        return;
+    }
+
+    // Get the address and size of VS_VERSION_INFO
+    PVOID Address = nullptr;
+    ULONG Size = 0;
+    Status = LdrAccessResource(Ntdll, ResourceDataEntry, &Address, &Size);
+    if (!NT_SUCCESS(Status))
+    {
+        DbgPrint("Failed to obtain size of VS_VERSION_INFO resource in ntdll.dll: %08X", Status);
+        return;
+    }
+    if (Address == nullptr || Size == 0)
+    {
+        DbgPrint("VS_VERSION_INFO resource in ntdll.dll has size zero");
+        return;
+    }
+
+    PatchFixedFileInfoVersion(hProcess, Address, Size);
+    PatchVersionString(hProcess, Address, Size, L"FileVersion");
+    PatchVersionString(hProcess, Address, Size, L"ProductVersion");
+}

--- a/Scylla/VersionPatch.h
+++ b/Scylla/VersionPatch.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <windows.h>
+#include <ntdll/ntdll.h>
+
+// Used for PEB OsBuildNumber patch and NTDLL version resource patches.
+#define FAKE_VERSION 1337
+
+void ApplyNtdllVersionPatch(HANDLE hProcess, PVOID Ntdll);

--- a/ScyllaHideGenericPlugin/ScyllaHideGenericPlugin.vcxproj
+++ b/ScyllaHideGenericPlugin/ScyllaHideGenericPlugin.vcxproj
@@ -146,6 +146,7 @@
     <ClCompile Include="..\InjectorCLI\DynamicMapping.cpp" />
     <ClCompile Include="..\InjectorCLI\RemoteHook.cpp" />
     <ClCompile Include="..\PluginGeneric\Injector.cpp" />
+    <ClCompile Include="..\Scylla\VersionPatch.cpp" />
     <ClCompile Include="ScyllaHideGenericPlugin.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -153,6 +154,7 @@
     <ClInclude Include="..\InjectorCLI\DynamicMapping.h" />
     <ClInclude Include="..\InjectorCLI\RemoteHook.h" />
     <ClInclude Include="..\PluginGeneric\Injector.h" />
+    <ClInclude Include="..\Scylla\VersionPatch.h" />
     <ClInclude Include="ScyllaHideGenericPlugin.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/ScyllaHideGenericPlugin/ScyllaHideGenericPlugin.vcxproj.filters
+++ b/ScyllaHideGenericPlugin/ScyllaHideGenericPlugin.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="..\PluginGeneric\Injector.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\Scylla\VersionPatch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\InjectorCLI\DynamicMapping.h">
@@ -45,6 +48,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="ScyllaHideGenericPlugin.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Scylla\VersionPatch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/ScyllaHideIDAProPlugin/ScyllaHideIDAProPlugin.vcxproj
+++ b/ScyllaHideIDAProPlugin/ScyllaHideIDAProPlugin.vcxproj
@@ -87,6 +87,7 @@
     <ClCompile Include="..\PluginGeneric\AttachDialog.cpp" />
     <ClCompile Include="..\PluginGeneric\Injector.cpp" />
     <ClCompile Include="..\PluginGeneric\OptionsDialog.cpp" />
+    <ClCompile Include="..\Scylla\VersionPatch.cpp" />
     <ClCompile Include="IdaServerClient.cpp" />
     <ClCompile Include="ScyllaHideIDAProPlugin.cpp" />
   </ItemGroup>
@@ -100,6 +101,7 @@
     <ClInclude Include="..\PluginGeneric\AttachDialog.h" />
     <ClInclude Include="..\PluginGeneric\Injector.h" />
     <ClInclude Include="..\PluginGeneric\OptionsDialog.h" />
+    <ClInclude Include="..\Scylla\VersionPatch.h" />
     <ClInclude Include="IdaServerClient.h" />
     <ClInclude Include="resource.h" />
   </ItemGroup>

--- a/ScyllaHideIDAProPlugin/ScyllaHideIDAProPlugin.vcxproj.filters
+++ b/ScyllaHideIDAProPlugin/ScyllaHideIDAProPlugin.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClCompile Include="..\PluginGeneric\AttachDialog.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\Scylla\VersionPatch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="ScyllaHideIDAProPlugin.rc">
@@ -68,6 +71,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\PluginGeneric\AttachDialog.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Scylla\VersionPatch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/ScyllaHideIDAServer/ScyllaHideIDAServer.vcxproj
+++ b/ScyllaHideIDAServer/ScyllaHideIDAServer.vcxproj
@@ -143,6 +143,7 @@
     <ClCompile Include="..\InjectorCLI\DynamicMapping.cpp" />
     <ClCompile Include="..\InjectorCLI\RemoteHook.cpp" />
     <ClCompile Include="..\PluginGeneric\Injector.cpp" />
+    <ClCompile Include="..\Scylla\VersionPatch.cpp" />
     <ClCompile Include="idaserver.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -150,6 +151,7 @@
     <ClInclude Include="..\InjectorCLI\DynamicMapping.h" />
     <ClInclude Include="..\InjectorCLI\RemoteHook.h" />
     <ClInclude Include="..\PluginGeneric\Injector.h" />
+    <ClInclude Include="..\Scylla\VersionPatch.h" />
     <ClInclude Include="idaserver.h" />
     <ClInclude Include="IdaServerExchange.h" />
     <ClInclude Include="resource.h" />

--- a/ScyllaHideIDAServer/ScyllaHideIDAServer.vcxproj.filters
+++ b/ScyllaHideIDAServer/ScyllaHideIDAServer.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="..\PluginGeneric\Injector.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\Scylla\VersionPatch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="idaserver.h">
@@ -51,6 +54,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="resource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Scylla\VersionPatch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/ScyllaHideOlly1Plugin/ScyllaHideOlly1Plugin.vcxproj
+++ b/ScyllaHideOlly1Plugin/ScyllaHideOlly1Plugin.vcxproj
@@ -84,6 +84,7 @@
     <ClCompile Include="..\PluginGeneric\OllyExceptionHandler.cpp" />
     <ClCompile Include="..\PluginGeneric\Injector.cpp" />
     <ClCompile Include="..\PluginGeneric\OptionsDialog.cpp" />
+    <ClCompile Include="..\Scylla\VersionPatch.cpp" />
     <ClCompile Include="olly1patches.cpp" />
     <ClCompile Include="ScyllaHideOlly1Plugin.cpp" />
   </ItemGroup>
@@ -95,6 +96,7 @@
     <ClInclude Include="..\PluginGeneric\OllyExceptionHandler.h" />
     <ClInclude Include="..\PluginGeneric\Injector.h" />
     <ClInclude Include="..\PluginGeneric\OptionsDialog.h" />
+    <ClInclude Include="..\Scylla\VersionPatch.h" />
     <ClInclude Include="olly1patches.h" />
     <ClInclude Include="resource.h" />
   </ItemGroup>

--- a/ScyllaHideOlly1Plugin/ScyllaHideOlly1Plugin.vcxproj.filters
+++ b/ScyllaHideOlly1Plugin/ScyllaHideOlly1Plugin.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClCompile Include="..\PluginGeneric\OllyExceptionHandler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\Scylla\VersionPatch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\InjectorCLI\DynamicMapping.h">
@@ -69,6 +72,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\PluginGeneric\OllyExceptionHandler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Scylla\VersionPatch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/ScyllaHideOlly2Plugin/ScyllaHideOlly2Plugin.vcxproj
+++ b/ScyllaHideOlly2Plugin/ScyllaHideOlly2Plugin.vcxproj
@@ -87,6 +87,7 @@
     <ClCompile Include="..\PluginGeneric\OllyExceptionHandler.cpp" />
     <ClCompile Include="..\PluginGeneric\Injector.cpp" />
     <ClCompile Include="..\PluginGeneric\OptionsDialog.cpp" />
+    <ClCompile Include="..\Scylla\VersionPatch.cpp" />
     <ClCompile Include="ScyllaHideOlly2Plugin.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -97,6 +98,7 @@
     <ClInclude Include="..\PluginGeneric\OllyExceptionHandler.h" />
     <ClInclude Include="..\PluginGeneric\Injector.h" />
     <ClInclude Include="..\PluginGeneric\OptionsDialog.h" />
+    <ClInclude Include="..\Scylla\VersionPatch.h" />
     <ClInclude Include="olly2patches.h" />
     <ClInclude Include="resource.h" />
   </ItemGroup>

--- a/ScyllaHideOlly2Plugin/ScyllaHideOlly2Plugin.vcxproj.filters
+++ b/ScyllaHideOlly2Plugin/ScyllaHideOlly2Plugin.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClCompile Include="..\PluginGeneric\OllyExceptionHandler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\Scylla\VersionPatch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\InjectorCLI\DynamicMapping.h">
@@ -66,6 +69,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="olly2patches.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Scylla\VersionPatch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/ScyllaHideTEPlugin/ScyllaHideTEPlugin.vcxproj
+++ b/ScyllaHideTEPlugin/ScyllaHideTEPlugin.vcxproj
@@ -145,6 +145,7 @@
     <ClCompile Include="..\InjectorCLI\DynamicMapping.cpp" />
     <ClCompile Include="..\InjectorCLI\RemoteHook.cpp" />
     <ClCompile Include="..\PluginGeneric\Injector.cpp" />
+    <ClCompile Include="..\Scylla\VersionPatch.cpp" />
     <ClCompile Include="ScyllaHideTEPlugin.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -152,6 +153,7 @@
     <ClInclude Include="..\InjectorCLI\DynamicMapping.h" />
     <ClInclude Include="..\InjectorCLI\RemoteHook.h" />
     <ClInclude Include="..\PluginGeneric\Injector.h" />
+    <ClInclude Include="..\Scylla\VersionPatch.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/ScyllaHideTEPlugin/ScyllaHideTEPlugin.vcxproj.filters
+++ b/ScyllaHideTEPlugin/ScyllaHideTEPlugin.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="..\PluginGeneric\Injector.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\Scylla\VersionPatch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\InjectorCLI\DynamicMapping.h">
@@ -42,6 +45,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\PluginGeneric\Injector.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Scylla\VersionPatch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/ScyllaHideX64DBGPlugin/ScyllaHideX64DBGPlugin.vcxproj
+++ b/ScyllaHideX64DBGPlugin/ScyllaHideX64DBGPlugin.vcxproj
@@ -157,6 +157,7 @@
     <ClCompile Include="..\PluginGeneric\AttachDialog.cpp" />
     <ClCompile Include="..\PluginGeneric\Injector.cpp" />
     <ClCompile Include="..\PluginGeneric\OptionsDialog.cpp" />
+    <ClCompile Include="..\Scylla\VersionPatch.cpp" />
     <ClCompile Include="ScyllaHideX64DBGPlugin.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -166,6 +167,7 @@
     <ClInclude Include="..\PluginGeneric\AttachDialog.h" />
     <ClInclude Include="..\PluginGeneric\Injector.h" />
     <ClInclude Include="..\PluginGeneric\OptionsDialog.h" />
+    <ClInclude Include="..\Scylla\VersionPatch.h" />
     <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>

--- a/ScyllaHideX64DBGPlugin/ScyllaHideX64DBGPlugin.vcxproj.filters
+++ b/ScyllaHideX64DBGPlugin/ScyllaHideX64DBGPlugin.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClCompile Include="..\PluginGeneric\AttachDialog.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\Scylla\VersionPatch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\PluginGeneric\OptionsDialog.h">
@@ -57,6 +60,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\PluginGeneric\AttachDialog.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Scylla\VersionPatch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This PR does the following changes in order to hide from VMProtect 3.6+:
* PEB OsBuildNumber changed from increment (which breaks on recent Win 10 builds such as 19043/19044) to `FAKE_VERSION` define.
* Consistency between what is set in PEB and what is written to NTDLL version resource.
* Extract NTDLL resource patching logic to separate file.
* Rewrite resource patching logic to NT API since it's required in HookLibrary.
* Also patch the other 3 versions in the resource and not just FileVersion.
* Add hooks to NtOpenFile/NtCreateSection/NtMapViewOfSection so we can patch the NTDLL image that VMProtect brings in from disk.

These measures successfully hide x32dbg on Windows 7 32-bit (newer 32-bit OSes should work as well). I tried to implement an x64 code path as well, but I didn't have a x64 sample to test with.